### PR TITLE
Allow for absolute and relative paths in micro._load()

### DIFF
--- a/rhc/micro.py
+++ b/rhc/micro.py
@@ -390,7 +390,8 @@ def _load(fname, files=None, lines=None):
         ll = l.split()
         if len(ll) > 1 and ll[0].lower() == 'import':
             import_fname = ' '.join(ll[1:])
-            import_fname = os.path.join(dir_path, import_fname)
+            if not import_fname.startswith('/'):  # path is relative
+                import_fname = os.path.join(dir_path, import_fname)
             _load(import_fname, files, lines)
         else:
             lines.append((fname, n, l))

--- a/rhc/micro.py
+++ b/rhc/micro.py
@@ -375,7 +375,7 @@ class FSM(object):
 
 
 def _load(fname, files=None, lines=None):
-
+    """Recursively load files."""
     if files is None:
         files = []
     if lines is None:
@@ -384,11 +384,13 @@ def _load(fname, files=None, lines=None):
     if fname in files:
         raise Exception('a micro file (in this case, %s) cannot be recursively imported' % fname)
     files.append(fname)
+    dir_path = os.path.dirname(fname)
 
     for n, l in enumerate(open(fname).readlines(), start=1):
         ll = l.split()
         if len(ll) > 1 and ll[0].lower() == 'import':
             import_fname = ' '.join(ll[1:])
+            import_fname = os.path.join(dir_path, import_fname)
             _load(import_fname, files, lines)
         else:
             lines.append((fname, n, l))

--- a/rhc/micro.py
+++ b/rhc/micro.py
@@ -390,7 +390,7 @@ def _load(fname, files=None, lines=None):
         ll = l.split()
         if len(ll) > 1 and ll[0].lower() == 'import':
             import_fname = ' '.join(ll[1:])
-            if not import_fname.startswith('/'):  # path is relative
+            if not import_fname.startswith(os.path.sep):  # path is relative
                 import_fname = os.path.join(dir_path, import_fname)
             _load(import_fname, files, lines)
         else:


### PR DESCRIPTION
For IMPORTs,

    - if the given path is relative, we make it absolute, relative to the inital input to _load.

    - If the path is absolute, we continue as before.


This is mainly useful for testing. We can call the tests from wherever (like the test directory) as opposed to the root of the project.