### PR TITLE
Changed setattr to be more accomodating.'

### DIFF
--- a/rhc/database/dao.py
+++ b/rhc/database/dao.py
@@ -146,10 +146,12 @@ class DAO(object):
     def __setattr__(self, name, value):
         if name.startswith('_') or name in self.FIELDS or name in self.PROPERTIES:
             self.__dict__[name] = value
-        elif isinstance(self.__class__.__dict__[name], property):
-            object.__setattr__(self, name, value)
         else:
-            raise AttributeError('%s is not a valid field name' % name)
+            object.__setattr__(self, name, value)
+        # elif isinstance(self.__class__.__dict__[name], property):
+        #     object.__setattr__(self, name, value)
+        # else:
+        #     raise AttributeError('%s is not a valid field name' % name)
 
     def _json(self, value):
         if isinstance(value, (datetime, date)):


### PR DESCRIPTION
This removes the previous property hack, which doesn't seem to work when inheritance is involved. Basically we default to the object.__setattr__ behavior if the attribute is not in FIELDS or PROPERTIES.

This lets me use property setters in inherited objects.