### PR TITLE
Changed DAO __getattr__ to do __getattribute__ instead of `raise Attr…

### DIFF
--- a/rhc/database/dao.py
+++ b/rhc/database/dao.py
@@ -136,7 +136,7 @@ class DAO(object):
         elif name in self.CHILDREN:
             result = self.children(self._import(self.CHILDREN[name]))  # children lookup
         else:
-            result = self.__getattribute__(name)
+            result = object.__getattribute__(self, name)
         return result
 
     def __getitem__(self, name):

--- a/rhc/database/dao.py
+++ b/rhc/database/dao.py
@@ -136,7 +136,7 @@ class DAO(object):
         elif name in self.CHILDREN:
             result = self.children(self._import(self.CHILDREN[name]))  # children lookup
         else:
-            raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, name))
+            result = self.__getattribute__(name)
         return result
 
     def __getitem__(self, name):
@@ -148,10 +148,6 @@ class DAO(object):
             self.__dict__[name] = value
         else:
             object.__setattr__(self, name, value)
-        # elif isinstance(self.__class__.__dict__[name], property):
-        #     object.__setattr__(self, name, value)
-        # else:
-        #     raise AttributeError('%s is not a valid field name' % name)
 
     def _json(self, value):
         if isinstance(value, (datetime, date)):


### PR DESCRIPTION
Changed DAO __getattr__ to do __getattribute__ instead of `raise Attribute Error` at the end of the if else statements.

This improves exception handling on properties, i.e. we will see the actual exception instead of "object has no attribute %r"

Ideally this will cut down on debug time. We won't have to hunt for why the property failed. It will be displayed in the traceback. Functionality should be the exact same.