### PR TITLE
Fix incorrect implicit unicode conversion.

### DIFF
--- a/rhc/httphandler.py
+++ b/rhc/httphandler.py
@@ -120,7 +120,8 @@ class HTTPHandler(BasicHandler):
 
     def __send(self, headers, content):
         self.on_http_send(headers, content)
-        data = (headers, content) if content else (headers,)
+        if isinstance(headers, unicode):
+            headers = headers.encode('utf8')
         data = headers + content
         super(HTTPHandler, self).send(data)
 


### PR DESCRIPTION
When "headers" is a unicode string and "content" is bytes, the implicit conversion would cause the below stack trace.

Also line 123 was superfluous so I removed it.

```
Jul 19 19:02:39 ip-172-30-3-23 UPLOAD: [ERROR] __main__:175> exception encountered
Traceback (most recent call last):
  File "/home/ubuntu/release-upload/lib/rhc/micro.py", line 169, in run
    SERVER.service(delay=sleep/1000.0, max_iterations=max_iterations)
  File "/home/ubuntu/release-upload/lib/rhc/tcpsocket.py", line 152, in service
    while (self._service(delay)):
  File "/home/ubuntu/release-upload/lib/rhc/tcpsocket.py", line 191, in _service
    self._poll_map[sock][0]()
  File "/home/ubuntu/release-upload/lib/rhc/tcpsocket.py", line 482, in _do_handshake
    self._on_ready()
  File "/home/ubuntu/release-upload/lib/rhc/tcpsocket.py", line 487, in _on_ready
    self.on_ready()
  File "/home/ubuntu/release-upload/lib/rhc/async.py", line 671, in on_ready
    self.send(method=ctx.method, host=ctx.host, resource=ctx.resource, headers=ctx.headers, content=ctx.content, close=ctx.close, compress=ctx.compress)
  File "/home/ubuntu/release-upload/lib/rhc/httphandler.py", line 155, in send
    self.__send(headers, content)
  File "/home/ubuntu/release-upload/lib/rhc/httphandler.py", line 124, in __send
    data = headers + content
UnicodeDecodeError: 'ascii' codec can't decode byte 0x89 in position 0: ordinal not in range(128)
```