### PR TITLE
Execute queries inside of a context manager.

### DIFF
--- a/rhc/database/db.py
+++ b/rhc/database/db.py
@@ -22,7 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 '''
 import pymysql
-import threading
 
 
 class _DB(object):
@@ -55,7 +54,7 @@ class _DB(object):
         return self
 
     @property
-    def  delta(self):
+    def delta(self):
         ''' only specify changed columns on update '''
         return self.__delta
 

--- a/rhc/database/query.py
+++ b/rhc/database/query.py
@@ -101,7 +101,9 @@ class Query(object):
             stmt += ' FOR UPDATE'
         return stmt
 
-    def execute(self, arg=None, one=False, limit=None, offset=None, for_update=False, generator=False, before_execute=None, after_execute=None):
+    def execute(self, arg=None, one=False, limit=None, offset=None,
+                for_update=False, generator=False, before_execute=None,
+                after_execute=None):
         self._stmt = self._build(one, limit, offset, for_update)
         self._executed_stmt = None
         if before_execute:

--- a/rhc/database/query.py
+++ b/rhc/database/query.py
@@ -115,20 +115,20 @@ class Query(object):
         return result
 
     def _execute(self, stmt, arg, after_execute):
-        cur = DB.cursor()
-        cur.execute(stmt, arg)
-        self._executed_stmt = cur._executed
-        if after_execute:
-            after_execute(self)
-        primary_table = self._classes[0].TABLE
-        for rs in cur:
-            s = {}
-            row = [t for t in zip(self._column_names, rs)]
-            for c in self._classes:
-                l = len(c.FIELDS) + len(c.CALCULATED_FIELDS)
-                val, row = row[:l], row[l:]
-                o = c(**dict(val))
-                s[c.TABLE] = o
-                o._tables = s
-            yield s[primary_table]
-        return
+        with DB as cur:
+            cur.execute(stmt, arg)
+            self._executed_stmt = cur._executed
+            if after_execute:
+                after_execute(self)
+            primary_table = self._classes[0].TABLE
+            for rs in cur:
+                s = {}
+                row = [t for t in zip(self._column_names, rs)]
+                for c in self._classes:
+                    l = len(c.FIELDS) + len(c.CALCULATED_FIELDS)
+                    val, row = row[:l], row[l:]
+                    o = c(**dict(val))
+                    s[c.TABLE] = o
+                    o._tables = s
+                yield s[primary_table]
+            return

--- a/rhc/database/test/test_basic.py
+++ b/rhc/database/test/test_basic.py
@@ -85,13 +85,13 @@ def test_foreign(data):
 
 
 def test_children(data):
-    p = next(Parent.list())
+    p = Parent.list()[0]
     c = p.children(Child)
     assert len(c) == 2
 
 
 def test_children_by_property(data):
-    p = next(Parent.list())
+    p = Parent.list()[0]
     c = p.child
     assert len(c) == 2
 


### PR DESCRIPTION
This is important since autocommit defaults to False with pymysql.
All queries are then start (or append to) a transaction. If
we are using the cursor directly, we will never commit that
transaction. The pending transaction may then block changes and
database maintenance.