### PR TITLE
Setting self.context.done = True before calling the callback in an async handler.

### DIFF
--- a/rhc/async.py
+++ b/rhc/async.py
@@ -690,8 +690,8 @@ class _Handler(HTTPHandler):
 
     def on_http_data(self):
         self.context.timer.delete()
-        self.callback.success(self)
         self.context.done = True
+        self.callback.success(self)
 
 
 class _URLParser(object):


### PR DESCRIPTION
This should fix the issue when there is an error in the callback,
which raises an aync _error (async.py ln 627), which in turn calls the callback
again since the handler context does not appear complete (even though
we already read the http content). These appear to always trigger a
socket close with 'premature close' (async.py ln 664).